### PR TITLE
Add GitHub Action Workflow to Run Sublime Text Syntax Test

### DIFF
--- a/.github/workflows/syntax-test.yml
+++ b/.github/workflows/syntax-test.yml
@@ -1,6 +1,7 @@
 name: Syntax Tests
 
 on:
+  workflow_dispatch: { }
   push:
     paths:
       - 'httpspec.YAML-tmLanguage'

--- a/.github/workflows/syntax-test.yml
+++ b/.github/workflows/syntax-test.yml
@@ -1,0 +1,29 @@
+name: Syntax Tests
+
+on:
+  push:
+    paths:
+      - 'httpspec.YAML-tmLanguage'
+      - 'httpspec.tmLanguage'
+  pull_request:
+    paths:
+      - 'httpspec.YAML-tmLanguage'
+      - 'httpspec.tmLanguage'
+
+jobs:
+  syntax_tests:
+    name: Syntax Tests (${{ matrix.build }})
+    strategy:
+      matrix:
+        include:
+          - build: latest  # This is the default
+            # packages: master  # If you depend on a default syntax definition
+          - build: 3210  # Latest known ST3 build with a test binary
+            # packages: st3
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: SublimeText/syntax-test-action@v2
+        with:
+          build: ${{ matrix.build }}
+          # default_packages: ${{ matrix.packages }}


### PR DESCRIPTION
Related to #5, this adds a GitHub Actions workflow that runs the referenced [SublimeText/syntax-test-action](https://github.com/SublimeText/syntax-test-action) and replicates the error message referenced in the OP.

Example run of the workflow: https://github.com/kbjr/Sublime-HTTP/actions/runs/3223943944/jobs/5274552914

![image](https://user-images.githubusercontent.com/195127/194992375-26192bc6-44d9-4600-bfee-5ba02e432d0e.png)
