### PR TITLE
Fix YAML typo resulting in syntax test failure

### DIFF
--- a/httpspec.YAML-tmLanguage
+++ b/httpspec.YAML-tmLanguage
@@ -66,7 +66,7 @@ repository:
   closingbracket:
     patterns:
     - name: keyword.other.multiplexend.httpspec
-    - match: \]
+      match: \]
 
   emptyline:
     patterns:

--- a/httpspec.tmLanguage
+++ b/httpspec.tmLanguage
@@ -51,8 +51,6 @@
 				<dict>
 					<key>name</key>
 					<string>keyword.other.multiplexend.httpspec</string>
-				</dict>
-				<dict>
 					<key>match</key>
 					<string>\]</string>
 				</dict>


### PR DESCRIPTION
Fixes the issue referenced in #5, resulting in the [SublimeText/syntax-test-action](https://github.com/SublimeText/syntax-test-action) passing successfully.

Successful action workflow: https://github.com/kbjr/Sublime-HTTP/actions/runs/3224032034

![image](https://user-images.githubusercontent.com/195127/194994782-bc695221-2199-497f-a181-2313fe6e9fb9.png)
