### PR TITLE
Update `statusline` pattern to allow for "HTTP/x" prefix

### DIFF
--- a/httpspec.YAML-tmLanguage
+++ b/httpspec.YAML-tmLanguage
@@ -45,7 +45,7 @@ repository:
 
   statusline:
     patterns:
-    - match: ^(\d\d\d)\s(.*)$
+    - match: ^(HTTP/(?:1\.1|2|3)\s)?(\d\d\d)\s(.*)$
       captures:
         '0': {name: constant.language.statustext.httpspec}
 

--- a/httpspec.tmLanguage
+++ b/httpspec.tmLanguage
@@ -312,7 +312,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>^(\d\d\d)\s(.*)$</string>
+					<string>^(HTTP/(?:1\.1|2|3)\s)?(\d\d\d)\s(.*)$</string>
 				</dict>
 			</array>
 		</dict>

--- a/httpspec.tmLanguage
+++ b/httpspec.tmLanguage
@@ -312,7 +312,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>^(HTTP/(?:1\.1|2|3)\s)?(\d\d\d)\s(.*)$</string>
+					<string>^(HTTP\/(?:1\.1|2|3)\s)?(\d\d\d)\s(.*)$</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
Fixes #6 

The existing `statusline` pattern assumes that the response starts immediately with the status code, so the following already works:

```http
200 OK
content-type: application/json
```

Rather than break that by requiring the prefix, I just added it as optional at the start of the status line, so now both

```http
200 OK
```

and

```http
HTTP/1.1 200 OK
```

should both match.



