### PR TITLE
Add support for absolute-form URIs

### DIFF
--- a/httpspec.YAML-tmLanguage
+++ b/httpspec.YAML-tmLanguage
@@ -98,10 +98,20 @@ repository:
         match: ^\,|\,(?=\s)
   uri:
     patterns:
+    - include: '#uriabsolute'
     - include: '#uripath'
     - include: '#multiplex'
     - include: '#questionmark'
     - include: '#uriquery'
+
+  uriabsolute:
+    patterns:
+    - name: support.function.httpspec
+      begin: (?:\s)(https?):\/\/((?:(?:[A-Za-z0-9\-]{1,63})\.)*(?:[A-Za-z0-9\-]{1,63}))
+      end: (?:$)
+      patterns:
+      - include: '#uripart'
+      - include: '#multiplex'
 
   uripath:
     patterns:

--- a/httpspec.tmLanguage
+++ b/httpspec.tmLanguage
@@ -334,6 +334,10 @@
 			<array>
 				<dict>
 					<key>include</key>
+					<string>#uriabsolute</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#uripath</string>
 				</dict>
 				<dict>
@@ -347,6 +351,31 @@
 				<dict>
 					<key>include</key>
 					<string>#uriquery</string>
+				</dict>
+			</array>
+		</dict>
+		<key>uriabsolute</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>begin</key>
+					<string>(?:\s)(https?):\/\/((?:(?:[A-Za-z0-9\-]{1,63})\.)*(?:[A-Za-z0-9\-]{1,63}))</string>
+					<key>end</key>
+					<string>(?:$)</string>
+					<key>name</key>
+					<string>support.function.httpspec</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#uripart</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#multiplex</string>
+						</dict>
+					</array>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
Fixes #7

Adds support for absolute-form requests (https://www.rfc-editor.org/rfc/rfc7230#section-5.3.2)

Tested (lightly) in VSCode:

![image](https://user-images.githubusercontent.com/195127/196068990-d2dce67e-1d00-4459-ab8f-55f428ae1b9a.png)

