### PR TITLE
Add definition in the newer `.sublime-syntax` file

### DIFF
--- a/.github/workflows/syntax-test.yml
+++ b/.github/workflows/syntax-test.yml
@@ -6,10 +6,12 @@ on:
     paths:
       - 'httpspec.YAML-tmLanguage'
       - 'httpspec.tmLanguage'
+      - 'httpspec.sublime-syntax'
   pull_request:
     paths:
       - 'httpspec.YAML-tmLanguage'
       - 'httpspec.tmLanguage'
+      - 'httpspec.sublime-syntax'
 
 jobs:
   syntax_tests:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ All 3 syntax files should be equivalent.
 
 The included `httpspec.sublime-syntax` file is generated from `httpspec.tmLanguage` file using the conversion utility built into Sublime Text 3211.
 
-In Subime Text with open the `.tmLanguage` file open, use the command palette to run the "Plugin Development: Convert Syntax to .sublime-syntax" option. This should open a new file tab with the generated YAML that can be copied into the `httpspec.sublime-syntax` file here.
+In Subime Text with the `.tmLanguage` file open, use the command palette to run the "Plugin Development: Convert Syntax to .sublime-syntax" option. This should open a new file tab with the generated YAML that can be copied into the `httpspec.sublime-syntax` file here.
 
 See <https://www.sublimetext.com/docs/syntax.html> for more general details on the `.sublime-syntax` file format

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 HTTP Syntax for Sublime Editor
 
-Please see discussion this PR for info on how to make edits: https://github.com/samsalisbury/Sublime-HTTP/pull/16
-
 All 3 syntax files should be equivalent.
+
+
+
+
+
+### Building the `.sublime-syntax` file from `.tmLanguage`
+
+The included `httpspec.sublime-syntax` file is generated from `httpspec.tmLanguage` file using the conversion utility built into Sublime Text 3211.
+
+In Subime Text with open the `.tmLanguage` file open, use the command palette to run the "Plugin Development: Convert Syntax to .sublime-syntax" option. This should open a new file tab with the generated YAML that can be copied into the `httpspec.sublime-syntax` file here.
+
+See <https://www.sublimetext.com/docs/syntax.html> for more general details on the `.sublime-syntax` file format

--- a/httpspec.YAML-tmLanguage
+++ b/httpspec.YAML-tmLanguage
@@ -7,6 +7,8 @@ uuid: 7bb6ff35-8b8a-4480-91ec-20f2d3fcba9a
 
 patterns:
 - name: meta.request.httpspec
+  begin: ''
+  end: ''
   patterns:
   - include: '#request'
   - match: ^$

--- a/httpspec.sublime-syntax
+++ b/httpspec.sublime-syntax
@@ -1,0 +1,126 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+name: HTTP Spec
+file_extensions:
+  - httpspec
+scope: source.httpspec
+contexts:
+  main:
+    - match: ""
+      push:
+        - meta_scope: meta.request.httpspec
+        - match: ""
+          pop: true
+        - include: request
+        - match: ^$
+        - include: response
+  ampersand:
+    - match: (?<!\&)\&(?!\&)
+      scope: support.function.ampersand.httpspec
+  closingbracket:
+    - match: '\]'
+      scope: keyword.other.multiplexend.httpspec
+  comma:
+    - match: \,
+      scope: keyword.other.comma.httpspec.test
+  emptyline:
+    - match: ^\s*$
+  equals:
+    - match: \=
+      scope: support.function.keyvaluepairseparator.httpspec
+  header:
+    - match: '^([^()<>@,;:\\"{} \t\x00-\x1F\x7F]+\:)\s(.*)$'
+      scope: string.unquoted.uri.httpspec
+      captures:
+        1: variable.parameter.headername.httpspec
+  invalidcomma:
+    - match: ^\,|\,(?=\s)
+      scope: invalid.illegal.comma.httpspec
+  jsonblock:
+    - include: scope:source.json
+  methodlist:
+    - include: methodname
+    - include: invalidcomma
+    - include: comma
+  methodname:
+    - match: (?:\b)(ACL|BASELINE-CONTROL|BIND|CHECKIN|CHECKOUT|CONNECT|COPY|DELETE|GET|HEAD|LABEL|LINK|LOCK|MERGE|MKACTIVITY|MKCALENDAR|MKCOL|MKREDIRECTREF|MKWORKSPACE|MOVE|OPTIONS|ORDERPATCH|PATCH|POST|PRI|PROPFIND|PROPPATCH|PUT|QUERY|REBIND|REPORT|SEARCH|TRACE|UNBIND|UNCHECKOUT|UNLINK|UNLOCK|UPDATE|UPDATEREDIRECTREF|VERSION-CONTROL)
+      scope: keyword.other.method.httpspec
+  multiplex:
+    - match: '(\[)'
+      captures:
+        0: keyword.other
+      push:
+        - match: '\]'
+          captures:
+            0: keyword.other
+          pop: true
+        - include: uripart
+        - include: comma
+  namevaluepair:
+    - include: uriqueryname
+    - include: equals
+    - include: uriqueryvalue
+  openingbracket:
+    - match: '\['
+      scope: keyword.other.multiplexstart.httpspec
+  questionmark:
+    - match: \?
+      scope: support.function.queryseparator.httpspec
+  request:
+    - match: |-
+        ^(?=ACL|BASELINE-CONTROL|BIND|CHECKIN|CHECKOUT|CONNECT|COPY|DELETE|GET|HEAD|LABEL|LINK|LOCK|MERGE|MKACTIVITY|MKCALENDAR|MKCOL|MKREDIRECTREF|MKWORKSPACE|MOVE|OPTIONS|ORDERPATCH|PATCH|POST|PRI|PROPFIND|PROPPATCH|PUT|QUERY|REBIND|REPORT|SEARCH|TRACE|UNBIND|UNCHECKOUT|UNLINK|UNLOCK|UPDATE|UPDATEREDIRECTREF|VERSION-CONTROL
+        )
+      push:
+        - match: ^(?=\d\d\d|HTTP)
+          pop: true
+        - include: requestline
+        - include: header
+        - include: jsonblock
+  requestline:
+    - include: methodlist
+    - include: uri
+  response:
+    - include: statusline
+    - include: header
+    - include: jsonblock
+  statusline:
+    - match: ^(\d\d\d)\s(.*)$
+      captures:
+        0: constant.language.statustext.httpspec
+    - match: ^HTTP/(1\.1|2|3)\s(\d\d\d)\s(.*)$
+      captures:
+        0: constant.language.statustext.httpspec
+  uri:
+    - include: uriabsolute
+    - include: uripath
+    - include: multiplex
+    - include: questionmark
+    - include: uriquery
+  uriabsolute:
+    - match: '(?:\s)(https?):\/\/((?:(?:[A-Za-z0-9\-]{1,63})\.)*(?:[A-Za-z0-9\-]{1,63}))'
+      push:
+        - meta_scope: support.function.httpspec
+        - match: (?:$)
+          pop: true
+        - include: uripart
+        - include: multiplex
+  uripart:
+    - match: '([a-bA-B0-9\-_/]+)'
+  uripath:
+    - match: (?:\s)\/
+      push:
+        - meta_scope: support.function.httpspec
+        - match: (?:$)
+          pop: true
+        - include: uripart
+        - include: multiplex
+  uriquery:
+    - include: namevaluepair
+    - include: ampersand
+  uriqueryname:
+    - match: "(?<=[?&])([^=&])+"
+      scope: support.function.uriqueryname.httpspec
+  uriqueryvalue:
+    - match: '(?<=\=)([^=&]+)'
+      scope: support.function.uriqueryvalue.httpspec

--- a/httpspec.tmLanguage
+++ b/httpspec.tmLanguage
@@ -13,6 +13,10 @@
 		<dict>
 			<key>name</key>
 			<string>meta.request.httpspec</string>
+			<key>begin</key>
+			<string></string>
+			<key>end</key>
+			<string></string>
 			<key>patterns</key>
 			<array>
 				<dict>


### PR DESCRIPTION
This PR adds a new file containing the `.sublime-syntax` file generated by using Sublime's built-in converter. This did require making a small change to the `.tmLanguage` file before the converter tool would recognize it, seen below:

```diff
diff --git a/httpspec.tmLanguage b/httpspec.tmLanguage
index 3b77816..2c07762 100644
--- a/httpspec.tmLanguage
+++ b/httpspec.tmLanguage
@@ -13,6 +13,10 @@
                <dict>
                        <key>name</key>
                        <string>meta.request.httpspec</string>
+                       <key>begin</key>
+                       <string></string>
+                       <key>end</key>
+                       <string></string>
                        <key>patterns</key>
                        <array>
                                <dict>
@@ -458,4 +462,4 @@
        <key>uuid</key>
        <string>7bb6ff35-8b8a-4480-91ec-20f2d3fcba9a</string>
 </dict>
```

See <http://www.sublimetext.com/docs/syntax.html> for details about the new `.sublime-syntax` format.